### PR TITLE
Add Result Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to `php-code-search` will be documented in this file.
 ## 1.4.0 - 2021-07-05
 
 - allow searching for static method calls like `MyClass` or `MyClass::someMethod`
+- add `ResultNode` class
+- add `node` property to `SearchResult` class
 
 ## 1.3.2 - 2021-07-05
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ To search a file, use the `search` method.  Its only parameter may be either a s
 
 To search a string instead, use the `searchCode` method.
 
+The search methods return an instance of `Permafrost\PhpCodeSearch\Results\FileSearchResults`, which has a `results` property.  
+
+Each `result` is an instance of `Permafrost\PhpCodeSearch\Results\SearchResult` with the following properties:
+
+- `node` - the specific item that was found
+  - `node->name(): string`
+- `location` - the location in the file that the item was found
+  - `location->startLine(): int`
+  - `location->endLine(): int`
+- `snippet` - a snippet of code lines from the file with the result line in the middle
+  - `snippet->getCode(): string`
+- `file()` _(method)_ - provides access to the file that was searched
+
 ### Variable names
 
 To search for variables by name, use the `variables` method before calling `search`.  To use regular expressions, surround the values with `/`.
@@ -41,7 +54,7 @@ $results = $searcher
     ->searchCode('<?php $oneA = "1a"; $oneB = "1b"; $oneC = "1c"; $twoA = "2a"; $twoB = "2b";');
     
 foreach($results as $result) {
-    echo "Found '{$result->location->name}' on line {$result->location->startLine}" . PHP_EOL;
+    echo "Found '{$result->node->name()}' on line {$result->location->startLine}" . PHP_EOL;
 }
 ```
 
@@ -59,7 +72,7 @@ $results = $searcher
     ->search('./file1.php');
     
 foreach($results as $result) {
-    echo "Found '{$result->location->name}' on line {$result->location->startLine}" . PHP_EOL;
+    echo "Found '{$result->node->name()}' on line {$result->location->startLine}" . PHP_EOL;
 }
 ```
 
@@ -80,7 +93,7 @@ $results = $searcher
     '');
     
 foreach($results as $result) {
-    echo "Found '{$result->location->name}' on line {$result->location->startLine}" . PHP_EOL;
+    echo "Found '{$result->node->name()}' on line {$result->location->startLine}" . PHP_EOL;
 }
 ```
 
@@ -100,7 +113,7 @@ $results = $searcher
     ->search('./app/Http/Controllers/MyController.php');
     
 foreach($results as $result) {
-    echo "Found '{$result->location->name}' on line {$result->location->startLine}" . PHP_EOL;
+    echo "Found '{$result->node->name()}' on line {$result->location->startLine}" . PHP_EOL;
 }
 ```
 
@@ -118,7 +131,7 @@ $results = $searcher
     ->search('./app/Http/Controllers/MyController.php');
     
 foreach($results as $result) {
-    echo "Found '{$result->location->name}' on line {$result->location->startLine}" . PHP_EOL;
+    echo "Found '{$result->node->name()}' on line {$result->location->startLine}" . PHP_EOL;
 }
 ```
 
@@ -136,7 +149,7 @@ $results = $searcher
     ->search('./app/Http/Controllers/MyController.php');
     
 foreach($results as $result) {
-    echo "Found '{$result->location->name}' on line {$result->location->startLine}" . PHP_EOL;
+    echo "Found '{$result->node->name()}' on line {$result->location->startLine}" . PHP_EOL;
 }
 ```
 
@@ -154,7 +167,7 @@ $results = $searcher
     ->searchCode('<?php $str = strtolower("TEST");');
     
 foreach($results as $result) {
-    echo "Found '{$result->location->name}' on line {$result->location->startLine}" . PHP_EOL;
+    echo "Found '{$result->node->name()}' on line {$result->location->startLine}" . PHP_EOL;
 }
 ```
 

--- a/src/Results/FileSearchResults.php
+++ b/src/Results/FileSearchResults.php
@@ -4,6 +4,7 @@ namespace Permafrost\PhpCodeSearch\Results;
 
 use Permafrost\PhpCodeSearch\Code\CodeLocation;
 use Permafrost\PhpCodeSearch\Code\CodeSnippet;
+use Permafrost\PhpCodeSearch\Results\Nodes\ResultNode;
 use Permafrost\PhpCodeSearch\Support\File;
 
 class FileSearchResults
@@ -26,11 +27,11 @@ class FileSearchResults
         $this->withSnippets = $withSnippets;
     }
 
-    public function addLocation(CodeLocation $location): self
+    public function add(ResultNode $resultNode, CodeLocation $location): self
     {
         $snippet = $this->makeSnippet($location->startLine());
 
-        $this->results[] = new SearchResult($location, $snippet, $this->file);
+        $this->results[] = new SearchResult($resultNode, $location, $snippet, $this->file);
 
         return $this;
     }

--- a/src/Results/Nodes/FunctionCallNode.php
+++ b/src/Results/Nodes/FunctionCallNode.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Permafrost\PhpCodeSearch\Results\Nodes;
+
+class FunctionCallNode implements ResultNode
+{
+    /** @var string */
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public static function create(string $name): self
+    {
+        return new static(...func_get_args());
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Results/Nodes/ResultNode.php
+++ b/src/Results/Nodes/ResultNode.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Permafrost\PhpCodeSearch\Results\Nodes;
+
+interface ResultNode
+{
+    public function name(): string;
+}

--- a/src/Results/Nodes/StaticMethodCallNode.php
+++ b/src/Results/Nodes/StaticMethodCallNode.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Permafrost\PhpCodeSearch\Results\Nodes;
+
+class StaticMethodCallNode implements ResultNode
+{
+    /** @var string */
+    public $className;
+
+    /** @var string */
+    public $methodName;
+
+    /** @var string */
+    public $name;
+
+    public function __construct(string $className, string $methodName)
+    {
+        $this->className = $className;
+        $this->methodName = $methodName;
+        $this->name = $this->name();
+    }
+
+    public static function create(string $className, string $methodName): self
+    {
+        return new static(...func_get_args());
+    }
+
+    public function name(): string
+    {
+        return "{$this->className}::{$this->methodName}";
+    }
+}

--- a/src/Results/Nodes/VariableNode.php
+++ b/src/Results/Nodes/VariableNode.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Permafrost\PhpCodeSearch\Results\Nodes;
+
+class VariableNode implements ResultNode
+{
+    /** @var string */
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public static function create(string $name): self
+    {
+        return new static(...func_get_args());
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Results/SearchResult.php
+++ b/src/Results/SearchResult.php
@@ -6,12 +6,19 @@ use Permafrost\PhpCodeSearch\Code\CodeLocation;
 use Permafrost\PhpCodeSearch\Code\CodeSnippet;
 use Permafrost\PhpCodeSearch\Code\FunctionCallLocation;
 use Permafrost\PhpCodeSearch\Code\StaticMethodCallLocation;
+use Permafrost\PhpCodeSearch\Results\Nodes\FunctionCallNode;
+use Permafrost\PhpCodeSearch\Results\Nodes\ResultNode;
+use Permafrost\PhpCodeSearch\Results\Nodes\StaticMethodCallNode;
+use Permafrost\PhpCodeSearch\Results\Nodes\VariableNode;
 use Permafrost\PhpCodeSearch\Support\File;
 
 class SearchResult
 {
     /** @var CodeLocation|FunctionCallLocation|StaticMethodCallLocation */
     public $location;
+
+    /** @var ResultNode|FunctionCallNode|StaticMethodCallNode|VariableNode */
+    public $node;
 
     /** @var CodeSnippet|null */
     public $snippet;
@@ -20,12 +27,14 @@ class SearchResult
     protected $file;
 
     /**
+     * @param ResultNode $node
      * @param CodeLocation $location
      * @param CodeSnippet|null $snippet
      * @param File|string $file
      */
-    public function __construct(CodeLocation $location, ?CodeSnippet $snippet, $file)
+    public function __construct(ResultNode $node, CodeLocation $location, ?CodeSnippet $snippet, $file)
     {
+        $this->node = $node;
         $this->location = $location;
         $this->snippet = $snippet;
         $this->file = is_string($file) ? new File($file) : $file;

--- a/src/Visitors/FunctionCallVisitor.php
+++ b/src/Visitors/FunctionCallVisitor.php
@@ -5,6 +5,9 @@ namespace Permafrost\PhpCodeSearch\Visitors;
 use Permafrost\PhpCodeSearch\Code\FunctionCallLocation;
 use Permafrost\PhpCodeSearch\Code\StaticMethodCallLocation;
 use Permafrost\PhpCodeSearch\Results\FileSearchResults;
+use Permafrost\PhpCodeSearch\Results\Nodes\FunctionCallNode;
+use Permafrost\PhpCodeSearch\Results\Nodes\StaticMethodCallNode;
+use Permafrost\PhpCodeSearch\Results\Nodes\VariableNode;
 use Permafrost\PhpCodeSearch\Support\Arr;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -30,17 +33,21 @@ class FunctionCallVisitor extends NodeVisitorAbstract
     {
         if ($node instanceof FuncCall) {
             if (Arr::matches($node->name, $this->functionNames, true)) {
+                $resultNode = FunctionCallNode::create($node->name->toString());
+
                 $location = FunctionCallLocation::create(
                     $node->name->parts[0],
                     $node->getStartLine(),
                     $node->getEndLine()
                 );
 
-                $this->results->addLocation($location);
+                $this->results->add($resultNode, $location);
             }
         }
 
         if ($node instanceof Node\Expr\StaticCall) {
+            $resultNode = StaticMethodCallNode::create($node->class->toString(), $node->name->toString());
+
             $location = StaticMethodCallLocation::create(
                 $node->class->parts[0],
                 $node->name->toString(),
@@ -48,45 +55,52 @@ class FunctionCallVisitor extends NodeVisitorAbstract
                 $node->getEndLine()
             );
 
-            $this->results->addLocation($location);
+            $this->results->add($resultNode, $location);
         }
 
         if ($node instanceof Node\Expr\MethodCall) {
+            $resultNode = FunctionCallNode::create($node->name->toString());
+
             $location = FunctionCallLocation::create(
                 $node->name->toString(),
                 $node->getStartLine(),
                 $node->getEndLine()
             );
 
-            $this->results->addLocation($location);
+            $this->results->add($resultNode, $location);
         }
 
         if ($node instanceof Node\Expr\Variable) {
             if (Arr::matches($node->name, $this->variableNames, true)) {
+                $resultNode = VariableNode::create($node->name);
+
                 $location = FunctionCallLocation::create(
                     $node->name,
                     $node->getStartLine(),
                     $node->getEndLine()
                 );
 
-                $this->results->addLocation($location);
+                $this->results->add($resultNode, $location);
             }
         }
 
         if ($node instanceof Node\Expr\New_) {
+            $resultNode = VariableNode::create($node->class->toString());
+
             $location = FunctionCallLocation::create(
                 $node->class->parts[0],
                 $node->getStartLine(),
                 $node->getEndLine()
             );
 
-            $this->results->addLocation($location);
+            $this->results->add($resultNode, $location);
         }
 
         if ($node instanceof Node\Expr\Assign) {
 //            print_r($node->expr->getSubNodeNames());
 //            print_r($node->var->getSubNodeNames());
 //            print_r([$node->var->name]);
+            $resultNode = FunctionCallNode::create($node->var->name);
 
             $location = FunctionCallLocation::create(
                 $node->var->name,
@@ -94,7 +108,7 @@ class FunctionCallVisitor extends NodeVisitorAbstract
                 $node->getEndLine()
             );
 
-            $this->results->addLocation($location);
+            $this->results->add($resultNode, $location);
         }
     }
 }

--- a/tests/Results/SearchResultTest.php
+++ b/tests/Results/SearchResultTest.php
@@ -4,6 +4,7 @@ namespace Permafrost\PhpCodeSearch\Tests\Results;
 
 use Permafrost\PhpCodeSearch\Code\CodeSnippet;
 use Permafrost\PhpCodeSearch\Code\FunctionCallLocation;
+use Permafrost\PhpCodeSearch\Results\Nodes\VariableNode;
 use Permafrost\PhpCodeSearch\Results\SearchResult;
 use Permafrost\PhpCodeSearch\Support\File;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,8 @@ class SearchResultTest extends TestCase
         $file = new File(tests_path('data/file2.txt'));
         $location = new FunctionCallLocation('my_func', 1, 1);
         $snippet = (new CodeSnippet())->fromFile($file);
-        $result = new SearchResult($location, $snippet, $file);
+        $resultNode = new VariableNode('myVar');
+        $result = new SearchResult($resultNode, $location, $snippet, $file);
 
         $this->assertMatchesObjectSnapshot($result);
     }

--- a/tests/Results/__snapshots__/SearchResultTest__it_creates_the_object_with_correct_properties__1.yml
+++ b/tests/Results/__snapshots__/SearchResultTest__it_creates_the_object_with_correct_properties__1.yml
@@ -3,5 +3,7 @@ location:
     column: 0
     endLine: 1
     startLine: 1
+node:
+    name: myVar
 snippet:
     code: { 1: '1', 2: '2', 3: '3', 4: '4', 5: '5' }

--- a/tests/__snapshots__/SearcherTest__it_searches_code_strings__1.yml
+++ b/tests/__snapshots__/SearcherTest__it_searches_code_strings__1.yml
@@ -1,3 +1,4 @@
 -
     location: { name: strtolower, column: 0, endLine: 2, startLine: 2 }
+    node: { name: strtolower }
     snippet: { code: { 1: '<?php', 2: '$myVar = strtolower(''test'');' } }

--- a/tests/__snapshots__/SearcherTest__it_searches_for_classes_created_by_new__1.yml
+++ b/tests/__snapshots__/SearcherTest__it_searches_for_classes_created_by_new__1.yml
@@ -1,3 +1,4 @@
 -
     location: { name: MyClass, column: 0, endLine: 13, startLine: 13 }
+    node: { name: MyClass }
     snippet: { code: { 9: '    {', 10: '        Ray::rateLimiter()->count(5);', 11: '    }', 12: '', 13: '    $obj = new MyClass();', 14: '', 15: '    $obj->withData([123])->send();', 16: '' } }

--- a/tests/__snapshots__/SearcherTest__it_searches_for_function_calls__1.yml
+++ b/tests/__snapshots__/SearcherTest__it_searches_for_function_calls__1.yml
@@ -1,6 +1,8 @@
 -
     location: { name: strtolower, column: 0, endLine: 4, startLine: 4 }
+    node: { name: strtolower }
     snippet: { code: { 1: '<?php', 2: '    ray(''12345'');', 3: '', 4: '    printf("%s\n", strtolower(''TEST''));', 5: '', 6: '    echo strtoupper(''test'') . PHP_EOL;', 7: '', 8: '    function test1()' } }
 -
     location: { name: strtoupper, column: 0, endLine: 6, startLine: 6 }
+    node: { name: strtoupper }
     snippet: { code: { 2: '    ray(''12345'');', 3: '', 4: '    printf("%s\n", strtolower(''TEST''));', 5: '', 6: '    echo strtoupper(''test'') . PHP_EOL;', 7: '', 8: '    function test1()', 9: '    {' } }

--- a/tests/__snapshots__/SearcherTest__it_searches_for_function_calls__2.yml
+++ b/tests/__snapshots__/SearcherTest__it_searches_for_function_calls__2.yml
@@ -1,12 +1,16 @@
 -
     location: { name: printf, column: 0, endLine: 4, startLine: 4 }
+    node: { name: printf }
     snippet: { code: { 1: '<?php', 2: '    ray(''12345'');', 3: '', 4: '    printf("%s\n", strtolower(''TEST''));', 5: '', 6: '    echo strtoupper(''test'') . PHP_EOL;', 7: '', 8: '    function test1()' } }
 -
     location: { name: strtolower, column: 0, endLine: 4, startLine: 4 }
+    node: { name: strtolower }
     snippet: { code: { 1: '<?php', 2: '    ray(''12345'');', 3: '', 4: '    printf("%s\n", strtolower(''TEST''));', 5: '', 6: '    echo strtoupper(''test'') . PHP_EOL;', 7: '', 8: '    function test1()' } }
 -
     location: { name: strtolower, column: 0, endLine: 4, startLine: 4 }
+    node: { name: strtolower }
     snippet: { code: { 1: '<?php', 2: '    ray(''12345'');', 3: '', 4: '    printf("%s\n", strtolower(''TEST''));', 5: '', 6: '    echo strtoupper(''test'') . PHP_EOL;', 7: '', 8: '    function test1()' } }
 -
     location: { name: strtoupper, column: 0, endLine: 6, startLine: 6 }
+    node: { name: strtoupper }
     snippet: { code: { 2: '    ray(''12345'');', 3: '', 4: '    printf("%s\n", strtolower(''TEST''));', 5: '', 6: '    echo strtoupper(''test'') . PHP_EOL;', 7: '', 8: '    function test1()', 9: '    {' } }

--- a/tests/__snapshots__/SearcherTest__it_searches_for_function_calls_without_snippets__1.yml
+++ b/tests/__snapshots__/SearcherTest__it_searches_for_function_calls_without_snippets__1.yml
@@ -1,6 +1,8 @@
 -
     location: { name: strtolower, column: 0, endLine: 4, startLine: 4 }
+    node: { name: strtolower }
     snippet: null
 -
     location: { name: strtoupper, column: 0, endLine: 6, startLine: 6 }
+    node: { name: strtoupper }
     snippet: null

--- a/tests/__snapshots__/SearcherTest__it_searches_for_static_method_calls__1.yml
+++ b/tests/__snapshots__/SearcherTest__it_searches_for_static_method_calls__1.yml
@@ -1,3 +1,4 @@
 -
     location: { className: Ray, methodName: rateLimiter, name: 'Ray::rateLimiter', column: 0, endLine: 10, startLine: 10 }
+    node: { className: Ray, methodName: rateLimiter, name: 'Ray::rateLimiter' }
     snippet: { code: { 6: '    echo strtoupper(''test'') . PHP_EOL;', 7: '', 8: '    function test1()', 9: '    {', 10: '        Ray::rateLimiter()->count(5);', 11: '    }', 12: '', 13: '    $obj = new MyClass();' } }

--- a/tests/__snapshots__/SearcherTest__it_searches_for_static_method_calls_containing_the_class_and_method_name__1.yml
+++ b/tests/__snapshots__/SearcherTest__it_searches_for_static_method_calls_containing_the_class_and_method_name__1.yml
@@ -1,3 +1,4 @@
 -
     location: { className: AnotherClass, methodName: enabled, name: 'AnotherClass::enabled', column: 0, endLine: 18, startLine: 18 }
+    node: { className: AnotherClass, methodName: enabled, name: 'AnotherClass::enabled' }
     snippet: { code: { 11: '    }', 12: '', 13: '    $obj = new MyClass();', 14: '', 15: '    $obj->withData([123])->send();', 16: '', 17: '    $isDisabled = AnotherClass::disabled();', 18: '    $isEnabled = AnotherClass::enabled();' } }

--- a/tests/__snapshots__/SearcherTest__it_searches_for_var_assignments__1.yml
+++ b/tests/__snapshots__/SearcherTest__it_searches_for_var_assignments__1.yml
@@ -1,6 +1,8 @@
 -
     location: { name: obj, column: 0, endLine: 13, startLine: 13 }
+    node: { name: obj }
     snippet: { code: { 9: '    {', 10: '        Ray::rateLimiter()->count(5);', 11: '    }', 12: '', 13: '    $obj = new MyClass();', 14: '', 15: '    $obj->withData([123])->send();', 16: '' } }
 -
     location: { name: MyClass, column: 0, endLine: 13, startLine: 13 }
+    node: { name: MyClass }
     snippet: { code: { 9: '    {', 10: '        Ray::rateLimiter()->count(5);', 11: '    }', 12: '', 13: '    $obj = new MyClass();', 14: '', 15: '    $obj->withData([123])->send();', 16: '' } }


### PR DESCRIPTION
This PR adds the `ResultNode` interface and implementations, in an effort to convert the `Location` classes to be more generic and not contain the name of the search result.