### PR TITLE
Fix matchesAny nested array bug

### DIFF
--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -46,8 +46,12 @@ class Arr
             $strings = [$strings];
         }
 
-        return collect($strings)->map(function (string $str) use ($values, $allowRegex) {
-            return self::matches($str, $values, $allowRegex);
+        return collect($strings)->map(function ($str) use ($values, $allowRegex) {
+            if (is_array($str)) {
+                return self::matchesAny($str, $values, $allowRegex);
+            }
+
+            return self::matches((string)$str, $values, $allowRegex);
         })->filter(function ($value) {
             return $value;
         })->count() > 0;

--- a/tests/Support/ArrTest.php
+++ b/tests/Support/ArrTest.php
@@ -34,4 +34,16 @@ class ArrTest extends TestCase
         $this->assertTrue(Arr::matches('test', ['/^te.+$/', 'one']));
         $this->assertFalse(Arr::matches('test', ['/^Test$/', '/^one$/']));
     }
+
+    /** @test */
+    public function it_matches_any_string_against_other_strings()
+    {
+        $this->assertTrue(Arr::matchesAny(['one', 'two'], ['abc', 'two']));
+    }
+
+    /** @test */
+    public function it_matches_any_nested_array_of_strings()
+    {
+        $this->assertTrue(Arr::matchesAny([ 'def', ['one', [ 'two' ] ] ], ['abc', 'two']));
+    }
 }


### PR DESCRIPTION
This PR fixes a bug in `Arr::matchesAny()` that caused an Exception if `$strings` contained a nested array.  It also adds unit tests for `matchesAny`.