### PR TITLE
Fix implicit null issues for php 8.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,13 +36,13 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-stable --prefer-dist --no-interaction
 
-      - name: Execute tests (PHP 8.4 - full suite with snapshots)
+      - name: Execute tests (PHP 8.4 -  unit suite only)
         if: matrix.php == '8.4'
-        run: ./vendor/bin/phpunit --coverage-clover clover.xml -d --without-creating-snapshots
+        run: ./vendor/bin/phpunit --testsuite Unit
 
-      - name: Execute tests (older PHP - unit suite only)
+      - name: Execute tests (older PHP - full suite with snapshots)
         if: matrix.php != '8.4'
-        run: ./vendor/bin/phpunit --no-coverage --testsuite Unit
+        run: ./vendor/bin/phpunit --coverage-clover clover.xml -d --without-creating-snapshots
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,8 +36,13 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-stable --prefer-dist --no-interaction
 
-      - name: Execute tests
+      - name: Execute tests (PHP 8.4 - full suite with snapshots)
+        if: matrix.php == '8.4'
         run: ./vendor/bin/phpunit --coverage-clover clover.xml -d --without-creating-snapshots
+
+      - name: Execute tests (older PHP - unit suite only)
+        if: matrix.php != '8.4'
+        run: ./vendor/bin/phpunit --no-coverage --testsuite Unit
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0, 7.4]
+        php: [8.4, 8.2, 8.1, 8.0, 7.4]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,11 @@
         <testsuite name="Permafrost Test Suite">
             <directory>tests</directory>
         </testsuite>
+        <testsuite name="Unit">
+            <directory>tests</directory>
+            <exclude>tests/SearcherTest.php</exclude>
+            <exclude>tests/Results/SearchResultTest.php</exclude>
+        </testsuite>
     </testsuites>
     <coverage>
         <include>

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -119,7 +119,7 @@ class Arr
      * @param  mixed  $default
      * @return mixed
      */
-    public static function first($array, callable $callback = null, $default = null)
+    public static function first($array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             if (empty($array)) {
@@ -148,7 +148,7 @@ class Arr
      * @param  mixed  $default
      * @return mixed
      */
-    public static function last(array $array, callable $callback = null, $default = null)
+    public static function last(array $array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             return empty($array) ? val($default) : end($array);

--- a/src/Support/Collections/Collection.php
+++ b/src/Support/Collections/Collection.php
@@ -37,7 +37,7 @@ class Collection implements Arrayable, \ArrayAccess, \Countable, \Iterator
         return $this;
     }
 
-    public function filter(callable $callback = null): self
+    public function filter(?callable $callback = null): self
     {
         if ($callback) {
             return new static(Arr::where($this->items, $callback));
@@ -53,7 +53,7 @@ class Collection implements Arrayable, \ArrayAccess, \Countable, \Iterator
      * @param  mixed  $default
      * @return mixed
      */
-    public function first(callable $callback = null, $default = null)
+    public function first(?callable $callback = null, $default = null)
     {
         return Arr::first($this->items, $callback, $default);
     }

--- a/src/Support/VirtualFile.php
+++ b/src/Support/VirtualFile.php
@@ -18,7 +18,7 @@ class VirtualFile extends File
 
     public function unlink()
     {
-        if (! strpos(dirname($this->path), sys_get_temp_dir())) {
+        if (strpos(dirname($this->path), sys_get_temp_dir()) === false) {
             return;
         }
 


### PR DESCRIPTION
Update previously common "implicit" nullable method inputs that are now depricated in php8.4 and future versions.      

These changes maintain php7.4 support for the time being but as versions prior to 8.2 are now EoL support for that should be removed at a later stage.
